### PR TITLE
Adding mowing data to the log

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Homebridge plugin to control Worx Landroid lawn mowers through the Worx Cloud, s
  - `pwd` Password for your Worx account
  - `rainsensor` Adds an additional "Leak" sensor for rain detection
  - `reload` Clears all mowers in HomeKit and reloads them from the cloud, default `false`
- - `debug` Enable additional log output, default `false`
+ - `debug` Enable additional debug log output, default `false`
+ - `mowdata` Enable additional mowing data log output, default `false`
 
 ## Usage
  The mower will appear as a switch and a contact sensor in HomeKit.

--- a/config.schema.json
+++ b/config.schema.json
@@ -32,7 +32,7 @@
       "description": "Shows additional debug info in the log",
       "type": "boolean",
       "required": false
-    }
+    },
     "mowdata":{
       "title": "Mowing Data Logging",
       "description": "Shows additional mowing data in the log",

--- a/config.schema.json
+++ b/config.schema.json
@@ -33,5 +33,11 @@
       "type": "boolean",
       "required": false
     }
+    "mowdata":{
+      "title": "Mowing Data Logging",
+      "description": "Shows additional mowing data in the log",
+      "type": "boolean",
+      "required": false
+    }
   }
 }

--- a/index.js
+++ b/index.js
@@ -300,7 +300,6 @@ function LandroidLogger(log){
   }
   this.trace = this.noLogMsg;
   this.debug = this.noLogMsg;
-  this.mowdata = this.noLogMsg;
   this.info = this.logMsg;
   this.warn = this.logMsg;
   this.error = this.logMsg;

--- a/index.js
+++ b/index.js
@@ -175,6 +175,31 @@ LandroidAccessory.prototype.landroidUpdate = function(mower, data, mowdata) {
     let oldDataset = this.dataset;
     this.dataset = new LandroidDataset(data);
 //    this.log("landroidUpdate ran with RSSI " + this.dataset.wifiQuality + ", battery temperature " + this.dataset.batteryTemperature);
+	if(mowdata){
+		if(oldDataset.totalTime != null && oldDataset.totalTime != undefined){
+			if(this.dataset.totalTime != oldDataset.totalTime){
+				totalTime = Number(this.dataset.totalTime) - Number(oldDataset.totalTime);
+				this.log("Landroid " + this.name + " new minutes worked: " + String(totalTime));
+			}
+			if(this.dataset.totalBladeTime != oldDataset.totalBladeTime){
+				totalBladeTime = Number(this.dataset.totalBladeTime) - Number(oldDataset.totalBladeTime);
+				this.log("Landroid " + this.name + " new minutes mowed: " + String(totalBladeTime));
+			}
+			if(this.dataset.totalDistance != oldDataset.totalDistance){
+				totalDistance = Number(this.dataset.totalDistance) - Number(oldDataset.totalDistance);
+				this.log("Landroid " + this.name + " new distance moved: " + String(totalDistance) + "m");
+			}
+		}else{
+			totalTime = Number(this.dataset.totalTime) / 60;
+			totalTime = totalTime.toFixed(2);
+			this.log("Landroid " + this.name + " hours worked so far: " + String(totalTime));
+			totalBladeTime = Number(this.dataset.totalBladeTime) / 60;
+			totalBladeTime = totalBladeTime.toFixed(2);
+			this.log("Landroid " + this.name + " hours mowed so far: " + String(totalBladeTime));
+			totalDistance = Number(this.dataset.totalDistance) / 1000;
+			this.log("Landroid " + this.name + " distance moved so far: " + String(totalDistance) + "km");
+		}
+	}
     if(this.dataset.batteryLevel != oldDataset.batteryLevel){
       this.log("Landroid " + this.name + " battery level changed to " + this.dataset.batteryLevel);
       this.accessory.getService(Service.BatteryService).getCharacteristic(Characteristic.BatteryLevel).updateValue(this.dataset.batteryLevel);
@@ -189,31 +214,6 @@ LandroidAccessory.prototype.landroidUpdate = function(mower, data, mowdata) {
         this.accessory.getService(Service.Switch).getCharacteristic(Characteristic.On).updateValue(true);
       }else{
         this.accessory.getService(Service.Switch).getCharacteristic(Characteristic.On).updateValue(false);
-      }
-      if(mowdata){
-        if(oldDataset.totalTime != null && oldDataset.totalTime != undefined){
-          if(this.dataset.totalTime != oldDataset.totalTime){
-            totalTime = Number(this.dataset.totalTime) - Number(oldDataset.totalTime);
-              this.log("Landroid " + this.name + " new minutes worked: " + String(totalTime));
-          }
-          if(this.dataset.totalBladeTime != oldDataset.totalBladeTime){
-            totalBladeTime = Number(this.dataset.totalBladeTime) - Number(oldDataset.totalBladeTime);
-            this.log("Landroid " + this.name + " new minutes mowed: " + String(totalBladeTime));
-          }
-          if(this.dataset.totalDistance != oldDataset.totalDistance){
-            totalDistance = Number(this.dataset.totalDistance) - Number(oldDataset.totalDistance);
-            this.log("Landroid " + this.name + " new distance moved: " + String(totalDistance) + "m");
-          }
-        }else{
-          totalTime = Number(this.dataset.totalTime) / 60;
-          totalTime = totalTime.toFixed(2);
-          this.log("Landroid " + this.name + " hours worked so far: " + String(totalTime));
-          totalBladeTime = Number(this.dataset.totalBladeTime) / 60;
-          totalBladeTime = totalBladeTime.toFixed(2);
-          this.log("Landroid " + this.name + " hours mowed so far: " + String(totalBladeTime));
-          totalDistance = Number(this.dataset.totalDistance) / 1000;
-          this.log("Landroid " + this.name + " distance moved so far: " + String(totalDistance) + "km");
-        }
       }
     }
     if(this.dataset.errorCode != oldDataset.errorCode){

--- a/index.js
+++ b/index.js
@@ -175,31 +175,31 @@ LandroidAccessory.prototype.landroidUpdate = function(mower, data, mowdata) {
     let oldDataset = this.dataset;
     this.dataset = new LandroidDataset(data);
     // this.log("landroidUpdate ran with RSSI " + this.dataset.wifiQuality + ", battery temperature " + this.dataset.batteryTemperature);
-		if(mowdata){
-			if(oldDataset.totalTime != null && oldDataset.totalTime != undefined){
-				if(this.dataset.totalTime != oldDataset.totalTime){
-					totalTime = Number(this.dataset.totalTime) - Number(oldDataset.totalTime);
-					this.log("Landroid " + this.name + " new minutes worked: " + String(totalTime));
-				}
-				if(this.dataset.totalBladeTime != oldDataset.totalBladeTime){
-					totalBladeTime = Number(this.dataset.totalBladeTime) - Number(oldDataset.totalBladeTime);
-					this.log("Landroid " + this.name + " new minutes mowed: " + String(totalBladeTime));
-				}
-				if(this.dataset.totalDistance != oldDataset.totalDistance){
-					totalDistance = Number(this.dataset.totalDistance) - Number(oldDataset.totalDistance);
-					this.log("Landroid " + this.name + " new distance moved: " + String(totalDistance) + "m");
-				}
-			}else{
-				totalTime = Number(this.dataset.totalTime) / 60;
-				totalTime = totalTime.toFixed(2);
-				this.log("Landroid " + this.name + " hours worked so far: " + String(totalTime));
-				totalBladeTime = Number(this.dataset.totalBladeTime) / 60;
-				totalBladeTime = totalBladeTime.toFixed(2);
-				this.log("Landroid " + this.name + " hours mowed so far: " + String(totalBladeTime));
-				totalDistance = Number(this.dataset.totalDistance) / 1000;
-				this.log("Landroid " + this.name + " distance moved so far: " + String(totalDistance) + "km");
-			}
-		}
+    if(mowdata){
+      if(oldDataset.totalTime != null && oldDataset.totalTime != undefined){
+        if(this.dataset.totalTime != oldDataset.totalTime){
+          totalTime = Number(this.dataset.totalTime) - Number(oldDataset.totalTime);
+          this.log("Landroid " + this.name + " new minutes worked: " + String(totalTime));
+        }
+        if(this.dataset.totalBladeTime != oldDataset.totalBladeTime){
+          totalBladeTime = Number(this.dataset.totalBladeTime) - Number(oldDataset.totalBladeTime);
+          this.log("Landroid " + this.name + " new minutes mowed: " + String(totalBladeTime));
+        }
+        if(this.dataset.totalDistance != oldDataset.totalDistance){
+          totalDistance = Number(this.dataset.totalDistance) - Number(oldDataset.totalDistance);
+          this.log("Landroid " + this.name + " new distance moved: " + String(totalDistance) + "m");
+        }
+      }else{
+        totalTime = Number(this.dataset.totalTime) / 60;
+        totalTime = totalTime.toFixed(2);
+        this.log("Landroid " + this.name + " hours worked so far: " + String(totalTime));
+        totalBladeTime = Number(this.dataset.totalBladeTime) / 60;
+        totalBladeTime = totalBladeTime.toFixed(2);
+        this.log("Landroid " + this.name + " hours mowed so far: " + String(totalBladeTime));
+        totalDistance = Number(this.dataset.totalDistance) / 1000;
+        this.log("Landroid " + this.name + " distance moved so far: " + String(totalDistance) + "km");
+      }
+    }
     if(this.dataset.batteryLevel != oldDataset.batteryLevel){
       this.log("Landroid " + this.name + " battery level changed to " + this.dataset.batteryLevel);
       this.accessory.getService(Service.BatteryService).getCharacteristic(Characteristic.BatteryLevel).updateValue(this.dataset.batteryLevel);

--- a/index.js
+++ b/index.js
@@ -175,31 +175,31 @@ LandroidAccessory.prototype.landroidUpdate = function(mower, data, mowdata) {
     let oldDataset = this.dataset;
     this.dataset = new LandroidDataset(data);
 //    this.log("landroidUpdate ran with RSSI " + this.dataset.wifiQuality + ", battery temperature " + this.dataset.batteryTemperature);
-	if(mowdata){
-		if(oldDataset.totalTime != null && oldDataset.totalTime != undefined){
-			if(this.dataset.totalTime != oldDataset.totalTime){
-				totalTime = Number(this.dataset.totalTime) - Number(oldDataset.totalTime);
-				this.log("Landroid " + this.name + " new minutes worked: " + String(totalTime));
+		if(mowdata){
+			if(oldDataset.totalTime != null && oldDataset.totalTime != undefined){
+				if(this.dataset.totalTime != oldDataset.totalTime){
+					totalTime = Number(this.dataset.totalTime) - Number(oldDataset.totalTime);
+					this.log("Landroid " + this.name + " new minutes worked: " + String(totalTime));
+				}
+				if(this.dataset.totalBladeTime != oldDataset.totalBladeTime){
+					totalBladeTime = Number(this.dataset.totalBladeTime) - Number(oldDataset.totalBladeTime);
+					this.log("Landroid " + this.name + " new minutes mowed: " + String(totalBladeTime));
+				}
+				if(this.dataset.totalDistance != oldDataset.totalDistance){
+					totalDistance = Number(this.dataset.totalDistance) - Number(oldDataset.totalDistance);
+					this.log("Landroid " + this.name + " new distance moved: " + String(totalDistance) + "m");
+				}
+			}else{
+				totalTime = Number(this.dataset.totalTime) / 60;
+				totalTime = totalTime.toFixed(2);
+				this.log("Landroid " + this.name + " hours worked so far: " + String(totalTime));
+				totalBladeTime = Number(this.dataset.totalBladeTime) / 60;
+				totalBladeTime = totalBladeTime.toFixed(2);
+				this.log("Landroid " + this.name + " hours mowed so far: " + String(totalBladeTime));
+				totalDistance = Number(this.dataset.totalDistance) / 1000;
+				this.log("Landroid " + this.name + " distance moved so far: " + String(totalDistance) + "km");
 			}
-			if(this.dataset.totalBladeTime != oldDataset.totalBladeTime){
-				totalBladeTime = Number(this.dataset.totalBladeTime) - Number(oldDataset.totalBladeTime);
-				this.log("Landroid " + this.name + " new minutes mowed: " + String(totalBladeTime));
-			}
-			if(this.dataset.totalDistance != oldDataset.totalDistance){
-				totalDistance = Number(this.dataset.totalDistance) - Number(oldDataset.totalDistance);
-				this.log("Landroid " + this.name + " new distance moved: " + String(totalDistance) + "m");
-			}
-		}else{
-			totalTime = Number(this.dataset.totalTime) / 60;
-			totalTime = totalTime.toFixed(2);
-			this.log("Landroid " + this.name + " hours worked so far: " + String(totalTime));
-			totalBladeTime = Number(this.dataset.totalBladeTime) / 60;
-			totalBladeTime = totalBladeTime.toFixed(2);
-			this.log("Landroid " + this.name + " hours mowed so far: " + String(totalBladeTime));
-			totalDistance = Number(this.dataset.totalDistance) / 1000;
-			this.log("Landroid " + this.name + " distance moved so far: " + String(totalDistance) + "km");
 		}
-	}
     if(this.dataset.batteryLevel != oldDataset.batteryLevel){
       this.log("Landroid " + this.name + " battery level changed to " + this.dataset.batteryLevel);
       this.accessory.getService(Service.BatteryService).getCharacteristic(Characteristic.BatteryLevel).updateValue(this.dataset.batteryLevel);

--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ function LandroidPlatform(log, config, api) {
       // remove old mowers 60 sec after connecting to cloud should be alright..
       self.removeTimeout = setTimeout(self.clearOldMowers.bind(self), 60000);
     } );
-    // self.landroidCloud.on("offline", offline => {console.log(offline)} );
-    // self.landroidCloud.on("online", online => {console.log(online)} );
+    //self.landroidCloud.on("offline", offline => {console.log(offline)} );
+    //self.landroidCloud.on("online", online => {console.log(online)} );
     // add link to cloud to restored accessories
     self.accessories.forEach(accessory=>{
       accessory.landroidCloud = self.landroidCloud;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function LandroidPlatform(log, config, api) {
   this.config = config;
   this.log = log;
   this.debug = config.debug || false;
+  this.mowdata = config.mowdata || false;
   this.accessories = [];
   this.cloudMowers = [];
 
@@ -45,8 +46,8 @@ function LandroidPlatform(log, config, api) {
       // remove old mowers 60 sec after connecting to cloud should be alright..
       self.removeTimeout = setTimeout(self.clearOldMowers.bind(self), 60000);
     } );
-    //self.landroidCloud.on("offline", offline => {console.log(offline)} );
-    //self.landroidCloud.on("online", online => {console.log(online)} );
+//    self.landroidCloud.on("offline", offline => {console.log(offline)} );
+//    self.landroidCloud.on("online", online => {console.log(online)} );
     // add link to cloud to restored accessories
     self.accessories.forEach(accessory=>{
       accessory.landroidCloud = self.landroidCloud;
@@ -86,6 +87,9 @@ LandroidPlatform.prototype.landroidFound = function(mower, data) {
   }else if(mower && mower.raw){
     this.log("Found Landroid in Worx Cloud with name: " + mower.raw.name);
   }
+  if(this.mowdata && mower && mower.raw) {
+    this.log("Mowing data logging enabled for Landroid " + mower.raw.name);
+  }
   this.cloudMowers.push(mower.raw.serial_number);
   for(var i = 0; i<this.accessories.length; i++){
     const accessory = this.accessories[i];
@@ -109,7 +113,7 @@ LandroidPlatform.prototype.landroidUpdate = function(mower, data) {
       this.log("[DEBUG] DATA: " + JSON.stringify(data));
     }
     this.accessories.forEach(accessory=>{
-        accessory.landroidUpdate(mower, data);
+        accessory.landroidUpdate(mower, data, this.mowdata);
     });
 }
 
@@ -162,12 +166,15 @@ function LandroidAccessory(platform, name, serial, accessory) {
     if(this.config.rainsensor && this.accessory.getService(Service.LeakSensor)) this.accessory.getService(Service.LeakSensor).on('get', this.getLeak.bind(this));
 }
 
-LandroidAccessory.prototype.landroidUpdate = function(mower, data) {
+LandroidAccessory.prototype.landroidUpdate = function(mower, data, mowdata) {
+  var totalTime, totalBladeTime, totalDistance;
+
   if(mower.raw.serial_number !== this.serial) return;
 
   if(data != null && data != undefined){
     let oldDataset = this.dataset;
     this.dataset = new LandroidDataset(data);
+//    this.log("landroidUpdate ran with RSSI " + this.dataset.wifiQuality + ", battery temperature " + this.dataset.batteryTemperature);
     if(this.dataset.batteryLevel != oldDataset.batteryLevel){
       this.log("Landroid " + this.name + " battery level changed to " + this.dataset.batteryLevel);
       this.accessory.getService(Service.BatteryService).getCharacteristic(Characteristic.BatteryLevel).updateValue(this.dataset.batteryLevel);
@@ -182,6 +189,31 @@ LandroidAccessory.prototype.landroidUpdate = function(mower, data) {
         this.accessory.getService(Service.Switch).getCharacteristic(Characteristic.On).updateValue(true);
       }else{
         this.accessory.getService(Service.Switch).getCharacteristic(Characteristic.On).updateValue(false);
+      }
+      if(mowdata){
+        if(oldDataset.totalTime != null && oldDataset.totalTime != undefined){
+          if(this.dataset.totalTime != oldDataset.totalTime){
+            totalTime = Number(this.dataset.totalTime) - Number(oldDataset.totalTime);
+              this.log("Landroid " + this.name + " new minutes worked: " + String(totalTime));
+          }
+          if(this.dataset.totalBladeTime != oldDataset.totalBladeTime){
+            totalBladeTime = Number(this.dataset.totalBladeTime) - Number(oldDataset.totalBladeTime);
+            this.log("Landroid " + this.name + " new minutes mowed: " + String(totalBladeTime));
+          }
+          if(this.dataset.totalDistance != oldDataset.totalDistance){
+            totalDistance = Number(this.dataset.totalDistance) - Number(oldDataset.totalDistance);
+            this.log("Landroid " + this.name + " new distance moved: " + String(totalDistance) + "m");
+          }
+        }else{
+          totalTime = Number(this.dataset.totalTime) / 60;
+          totalTime = totalTime.toFixed(2);
+          this.log("Landroid " + this.name + " hours worked so far: " + String(totalTime));
+          totalBladeTime = Number(this.dataset.totalBladeTime) / 60;
+          totalBladeTime = totalBladeTime.toFixed(2);
+          this.log("Landroid " + this.name + " hours mowed so far: " + String(totalBladeTime));
+          totalDistance = Number(this.dataset.totalDistance) / 1000;
+          this.log("Landroid " + this.name + " distance moved so far: " + String(totalDistance) + "km");
+        }
       }
     }
     if(this.dataset.errorCode != oldDataset.errorCode){
@@ -268,6 +300,7 @@ function LandroidLogger(log){
   }
   this.trace = this.noLogMsg;
   this.debug = this.noLogMsg;
+  this.mowdata = this.noLogMsg;
   this.info = this.logMsg;
   this.warn = this.logMsg;
   this.error = this.logMsg;

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ LandroidAccessory.prototype.landroidUpdate = function(mower, data, mowdata) {
   if(data != null && data != undefined){
     let oldDataset = this.dataset;
     this.dataset = new LandroidDataset(data);
-//    this.log("landroidUpdate ran with RSSI " + this.dataset.wifiQuality + ", battery temperature " + this.dataset.batteryTemperature);
+    // this.log("landroidUpdate ran with RSSI " + this.dataset.wifiQuality + ", battery temperature " + this.dataset.batteryTemperature);
 		if(mowdata){
 			if(oldDataset.totalTime != null && oldDataset.totalTime != undefined){
 				if(this.dataset.totalTime != oldDataset.totalTime){

--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ function LandroidPlatform(log, config, api) {
       // remove old mowers 60 sec after connecting to cloud should be alright..
       self.removeTimeout = setTimeout(self.clearOldMowers.bind(self), 60000);
     } );
-//    self.landroidCloud.on("offline", offline => {console.log(offline)} );
-//    self.landroidCloud.on("online", online => {console.log(online)} );
+    // self.landroidCloud.on("offline", offline => {console.log(offline)} );
+    // self.landroidCloud.on("online", online => {console.log(online)} );
     // add link to cloud to restored accessories
     self.accessories.forEach(accessory=>{
       accessory.landroidCloud = self.landroidCloud;


### PR DESCRIPTION
The proposed feature adds additional mowing data output to the log under the control of a configuration switch. A total so far is output when the service 1st starts and then an update is output every time an MQTT packet is sent by the Landroid. On my mower it seems a bit random when this actually happens, sometimes it's every 10 minutes but usually it's only when the mower status changes.