### PR TITLE
PartyMode switch now reacts properly to state from CloudConnector (Issue: #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ This is the change log for the plugin, all relevant changes will be listed here.
 
 For documentation please see the [README](https://github.com/normen/homebridge-landroid/blob/master/README.md)
 
+## 0.11.9
+- PartyMode switch now properly reflects PartyMode state
+
 ## 0.11.8
 - Attempt to fix party mode status
 

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ Note: If you update from Version <= 0.9.5 or enable the sensor after first setup
 You can see the battery status in the settings of either the switch or contact sensor in the Home app and you can ask Siri about the battery status of your lawn mower.
 
 ## Development
-If you want new features or improve the plugin, you're very welcome to do so. The projects `devDependencies` include homebridge and the `npm run test` command has been adapted so that you can run a test instance of homebridge during development. 
+If you want new features or improve the plugin, you're very welcome to do so. The projects `devDependencies` include homebridge and the `npm run test` command has been adapted so that you can run a test instance of homebridge during development. Alternatively you can use `npm run dev` if you have homebridge installed as a global package
 #### Setup
 - clone github repo
 - `npm install` in the project folder
 - create `.homebridge` folder in project root
 - add `config.json` with appropriate content to `.homebridge` folder
 - run `npm run test` to start the homebridge instance for testing
+- alternatively run `npm run dev` to start homebridge if its installed as a global package
 
 #### Notes
 Most of the connector code is directly copied from [iobroker.worx](https://github.com/iobroker-community-adapters/ioBroker.worx), a helper script called 'sync-code' allows updating to the latest version of that code.

--- a/index.js
+++ b/index.js
@@ -67,7 +67,8 @@ function LandroidPlatform(log, config, api) {
       } else if(objectname.includes(".mower.")){
         let serial = objectname.substring(0, objectname.indexOf("."));
         let item = objectname.split('.').pop();
-        if(object && object.val){
+
+        if(object && (object.val !== null || object.val !== undefined)) {
           self.landroidUpdate(serial, item, object.val);
         }
       }
@@ -143,14 +144,14 @@ LandroidPlatform.prototype.createUpdate = function(objectname, object) {
   if(objectname.includes(".mower.")){
     let serial = objectname.substring(0, objectname.indexOf("."));
     let item = objectname.split('.').pop();
-    if(object && object.val){
+    if(object && (object.val !== null || object.val !== undefined)) {
       this.landroidUpdate(serial, item, object.val);
     }
   }
 }
 
 LandroidPlatform.prototype.landroidUpdate = function(serial, item, data) {
-    if(this.debug && data) {
+    if(this.debug) {
       this.log("[DEBUG] DATA: " + item + ": " + JSON.stringify(data));
     }
     this.accessories.forEach(accessory=>{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-landroid",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "HomeBridge plugin for Worx Landroid lawnmowers",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "HomeBridge plugin for Worx Landroid lawnmowers",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/homebridge/bin/homebridge -P ./ -I -U ./.homebridge"
+    "test": "./node_modules/homebridge/bin/homebridge -P ./ -I -U ./.homebridge",
+    "dev": "homebridge -P ./ -I -U ./.homebridge"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
After a bunch of ´console.log()´ later, i managed to figure out the data was perfectly fine, but since its `object.val` was false when disabled, it would not be passed into the data for the plugin to consume. Simply adding a `null` and `undefined` check made it work.

Only issue i still see, is that the Homekit switch is waiting for response from the CloudConnector when making a change. This is causing the Plugin (or switch) to show up as "No response". But the correct information is still being sent back and forth.