### PR TITLE
Updated worx domain

### DIFF
--- a/CloudConnector.js
+++ b/CloudConnector.js
@@ -71,7 +71,7 @@ class Worx extends Adapter {
         this.clouds = {
             worx: {
                 url: "api.worxlandroid.com",
-                loginUrl: "https://id.eu.worx.com/",
+                loginUrl: "https://id.worx.com/",
                 clientId: "150da4d2-bb44-433b-9429-3773adc70a2a",
                 redirectUri: "com.worxlandroid.landroid://oauth-callback/",
                 mqttPrefix: "WX",


### PR DESCRIPTION
Since the URI to the worx cloud changed from `id.eu.worx.com` to `id.worx.com`, the plugin no longer worx.
I have only changed the string in the config and not yet validated, that this is the only thing which didn't work.

According to #63 this should be the only necessary fix.